### PR TITLE
Pin latex2mathml<3.78 to restore Python 3.8 support

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@
 - Remove trailing space after postfix comma
 - Fix `<mtable>` column width
 - Adjust whitespace in aligned environment
+- Pin `latex2mathml<3.78` to honor `python_requires = >= 3.8`
+  (3.78 dropped 3.8 support via PEP 585 syntax)
 
 
 0.12 - 2025-03-02

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ python_requires = >= 3.8
 include_package_data = True
 install_requires =
     ziafont>=0.10
-    latex2mathml
+    latex2mathml<3.78
 
 [options.package_data]
 ziamath = 


### PR DESCRIPTION
## Problem

`ziamath` declares `python_requires = >= 3.8` and lists Python 3.8 in its classifiers, but a fresh `pip install ziamath` on Python 3.8 fails at import time:

```
TypeError: 'type' object is not subscriptable
  File ".../latex2mathml/commands.py", line 105, in <module>
    EXTENSIBLE_ARROWS: dict[str, str] = {
```

## Cause

The `install_requires` for `latex2mathml` is unpinned, and `latex2mathml` 3.78.0 (May 2025) introduced PEP 585 built-in generic syntax (`dict[str, str]`) and PEP 604 union syntax (`int | None`), which only work on Python 3.9+. 3.78.0 bumped upstream's own `requires-python` to `>=3.9`, and 3.81.0 bumped it again to `>=3.10`. So:

- `latex2mathml 3.77.x` and earlier → works on Python 3.8
- `latex2mathml 3.78.x–3.80.x` → requires Python 3.9+
- `latex2mathml 3.81.x` → requires Python 3.10+

A user who runs `pip install ziamath` on Python 3.8 today (e.g. via an Inkscape AppImage that bundles CPython 3.8) resolves to the latest `latex2mathml` and gets the `TypeError` on `import ziamath`.

## Fix

Pin `latex2mathml<3.78` in `setup.cfg` so the upper bound matches the project's stated `python_requires = >= 3.8`. This excludes the two releases that broke 3.8 compatibility while still pulling the latest 3.77.x with all the latest bug fixes.

## Verification

Confirmed on Python 3.8.10 (Inkscape AppImage bundled interpreter) with the pinned constraint:

```python
import ziamath as zm
m = zm.Math.fromlatex(r'\alpha + \beta = \gamma')
print(len(m.svg()))   # → 5172
```

The complex README test (matrix algebra from `test_formula.txt`) also renders cleanly (141 KB SVG).

## Trade-off note

This pin freezes ziamath on a `latex2mathml` line that is no longer receiving new features. If/when upstream `ziamath` decides to drop 3.8, the pin can simply be removed.